### PR TITLE
Silently skip non-existent schema files

### DIFF
--- a/src/createInterface.js
+++ b/src/createInterface.js
@@ -8,6 +8,10 @@ module.exports = (schemaPath, interfaceName) => {
   tsInterface += `  id: number;\n`;
   var schemaFile;
   var schema;
+  if (!fs.existsSync(schemaPath)) {
+    return null;
+  }
+
   try {
     schemaFile = fs.readFileSync(schemaPath, 'utf8');
     schema = JSON.parse(schemaFile);


### PR DESCRIPTION
Another addition to avoid false-positive errors in the logs.